### PR TITLE
remove extra whitespaces

### DIFF
--- a/src/xmleam/xml_builder.gleam
+++ b/src/xmleam/xml_builder.gleam
@@ -60,7 +60,7 @@ pub fn new_advanced_document(version: String, encoding: String) -> XmlBuilder {
   |> string_builder.append(version)
   |> string_builder.append("\" encoding=\"")
   |> string_builder.append(encoding)
-  |> string_builder.append("\"?> \n")
+  |> string_builder.append("\"?>\n")
   |> Ok
 }
 
@@ -90,11 +90,11 @@ pub fn tag(document: XmlBuilder, label: String, contents: String) -> XmlBuilder 
       string_builder.new()
       |> append("<")
       |> append(label)
-      |> append("> ")
+      |> append(">")
       |> append(contents)
-      |> append(" </")
+      |> append("</")
       |> append(label)
-      |> append("> \n")
+      |> append(">\n")
       |> append_builder(
         to: result.unwrap(document, string_builder.new()),
         suffix: _,
@@ -119,13 +119,13 @@ pub fn cdata_tag(document: XmlBuilder, label: String, contents: String) {
       string_builder.new()
       |> append("<")
       |> append(label)
-      |> append("> \n")
+      |> append(">\n")
       |> append("<![CDATA[\n \t")
       |> append(contents)
-      |> append("\n]]> \n")
+      |> append("\n]]>\n")
       |> append("</")
       |> append(label)
-      |> append("> \n")
+      |> append(">\n")
       |> append_builder(
         to: result.unwrap(document, string_builder.new()),
         suffix: _,
@@ -157,11 +157,11 @@ pub fn option_content_tag(
       |> append("<")
       |> append(label)
       |> append_builder(string_options(options))
-      |> append("> ")
+      |> append(">")
       |> append(contents)
-      |> append(" </")
+      |> append("</")
       |> append(label)
-      |> append("> \n")
+      |> append(">\n")
       |> append_builder(
         to: result.unwrap(document, string_builder.new()),
         suffix: _,
@@ -186,7 +186,7 @@ pub fn option_tag(document: XmlBuilder, label: String, options: List(Option)) {
       |> append("<")
       |> append(label)
       |> append_builder(string_options(options))
-      |> append(" />\n")
+      |> append("/>\n")
       |> append_builder(
         to: result.unwrap(document, string_builder.new()),
         suffix: _,
@@ -231,11 +231,11 @@ pub fn block_tag(document: XmlBuilder, label: String, inner: XmlBuilder) {
           string_builder.new()
           |> append("<")
           |> append(label)
-          |> append("> \n")
+          |> append(">\n")
           |> append_builder(result.unwrap(inner, string_builder.new()))
           |> append("</")
           |> append(label)
-          |> append("> \n")
+          |> append(">\n")
           |> append_builder(
             to: result.unwrap(document, string_builder.new()),
             suffix: _,
@@ -272,11 +272,11 @@ pub fn option_block_tag(
           |> append("<")
           |> append(label)
           |> append_builder(string_options(options))
-          |> append("> \n")
+          |> append(">\n")
           |> append_builder(result.unwrap(inner, string_builder.new()))
-          |> append(" </")
+          |> append("</")
           |> append(label)
-          |> append("> \n")
+          |> append(">\n")
           |> append_builder(
             to: result.unwrap(document, string_builder.new()),
             suffix: _,
@@ -324,9 +324,9 @@ pub fn block_comment(document: XmlBuilder, inner: XmlBuilder) {
 
         False ->
           string_builder.new()
-          |> append("<!-- \n")
+          |> append("<!--\n")
           |> append_builder(result.unwrap(inner, string_builder.new()))
-          |> append("--> \n")
+          |> append("-->\n")
           |> append_builder(
             to: result.unwrap(document, string_builder.new()),
             suffix: _,

--- a/test/xmleam_test.gleam
+++ b/test/xmleam_test.gleam
@@ -22,7 +22,7 @@ pub fn xml_builder_cdata_test() {
   |> xml_builder.end_xml
   |> result.unwrap("ERROR")
   |> should.equal(
-    "<link> \n<![CDATA[\n \t<a href=\"https://example.com\"> link </a>\n]]> \n</link> \n",
+    "<link>\n<![CDATA[\n \t<a href=\"https://example.com\"> link </a>\n]]>\n</link>\n",
   )
 }
 
@@ -48,7 +48,7 @@ pub fn xml_builder_full_test() {
   |> end_xml()
   |> result.unwrap("ERROR")
   |> should.equal(
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<rss xmlns:itunes=\"http://www.itunes.com/dtds/podcast-1.0.dtd\"> \n<channel> \n<title> Example RSS Feed </title> \n<description> this is a teaching example for xmleam </description> \n</channel> \n<item> \n<title> Example Item </title> \n</item> \n </rss> \n",
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<rss xmlns:itunes=\"http://www.itunes.com/dtds/podcast-1.0.dtd\">\n<channel>\n<title>Example RSS Feed</title>\n<description>this is a teaching example for xmleam</description>\n</channel>\n<item>\n<title>Example Item</title>\n</item>\n</rss>\n",
   )
 
   xml_builder.new_document()
@@ -57,7 +57,7 @@ pub fn xml_builder_full_test() {
   |> end_xml()
   |> result.unwrap("ERROR")
   |> should.equal(
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<link href=\"https://example.com\" idk=\"N/A\" />\n<hello world=\"Earth\"> AAAAAAA </hello> \n",
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<link href=\"https://example.com\" idk=\"N/A\"/>\n<hello world=\"Earth\">AAAAAAA</hello>\n",
   )
 
   xml_builder.new()
@@ -73,5 +73,5 @@ pub fn xml_builder_full_test() {
   })
   |> end_xml()
   |> result.unwrap("ERROR")
-  |> should.equal("<!-- \n<hello> world </hello> \n--> \n")
+  |> should.equal("<!--\n<hello>world</hello>\n-->\n")
 }


### PR DESCRIPTION
When trying to validate a generated feed using this library, the w3 validator complains about extra whitespaces: https://validator.w3.org/feed/docs/error/UnexpectedWhitespace.html

Forced extra whitespace makes the generated xml somewhat easier to read but can possibly introduce incompatibilities with certain xml namespaces and/or specifications.

I have adjusted the tests accordingly.